### PR TITLE
Add example Bitrix24 REST client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# gpt
+# Bitrix24 Time Log Fetcher
+
+This repository contains a small example script for fetching time log entries from Bitrix24 via the REST API.
+
+## Usage
+
+1. Create a `.env` file in the project root with the following content:
+
+```
+WEBHOOK_URL=https://<your_portal>.bitrix24.ru/rest/<user_id>/<webhook_key>/
+```
+
+2. Install the dependencies in a virtual environment:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+3. Run the script:
+
+```bash
+python main.py
+```
+
+The script prints all time log entries for June 2025 using the `task.elapseditem.getlist` method.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,57 @@
+import requests
+import calendar
+from datetime import datetime
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+WEBHOOK_BASE = os.getenv('WEBHOOK_URL')
+if not WEBHOOK_BASE:
+    raise RuntimeError('WEBHOOK_URL not found in .env')
+
+WEBHOOK_URL = WEBHOOK_BASE.rstrip('/') + '/task.elapseditem.getlist.json'
+
+YEAR = 2025
+MONTH = 6
+
+
+def get_month_date_range(year: int, month: int):
+    start = datetime(year, month, 1)
+    last_day = calendar.monthrange(year, month)[1]
+    end = datetime(year, month, last_day, 23, 59, 59)
+    return start, end
+
+
+def fetch_time_logs(start_date, end_date, page_size=50):
+    logs = []
+    page = 1
+    while True:
+        payload = [
+            {},
+            {
+                '>=CREATED_DATE': start_date.strftime('%Y-%m-%d'),
+                '<=CREATED_DATE': end_date.strftime('%Y-%m-%d')
+            },
+            ['ID', 'TASK_ID', 'USER_ID', 'CREATED_DATE', 'SECONDS'],
+            {'NAV_PARAMS': {'nPageSize': page_size, 'iNumPage': page}}
+        ]
+        resp = requests.post(WEBHOOK_URL, json=payload, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        logs.extend(data.get('result', []))
+        if not data.get('next'):
+            break
+        page += 1
+    return logs
+
+
+def main():
+    start_date, end_date = get_month_date_range(YEAR, MONTH)
+    logs = fetch_time_logs(start_date, end_date)
+    for log in logs:
+        print(log)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+python-dotenv


### PR DESCRIPTION
## Summary
- add an example script (`main.py`) for fetching time log entries from Bitrix24
- document usage of the script
- list runtime requirements

## Testing
- `pip install -r requirements.txt`
- `python main.py` *(fails: ProxyError due to example URL)*

------
https://chatgpt.com/codex/tasks/task_e_6866c29d62e0832d9adb9036b7f04b99