### PR TITLE
Fix task retrieval endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-3. Run the script:
+3. Run the script. Use `--year` and `--month` to specify the starting month.
+   Set `--months` to span multiple months and pass `--show-projects` to print
+   the list of active projects for the selected period.
 
 ```bash
-python main.py
+python main.py --year 2025 --month 6 --months 2 --show-projects
 ```
 
-The script prints all time log entries for June 2025 using the `task.elapseditem.getlist` method.
+The command above prints all time log entries for June and July 2025 and shows
+the IDs of projects with any activity during that period.
 
 ## Docker
 

--- a/bitrix_client.py
+++ b/bitrix_client.py
@@ -1,0 +1,16 @@
+import os
+import requests
+from typing import List, Dict, Any
+
+class BitrixClient:
+    def __init__(self, webhook_url: str | None = None) -> None:
+        self.webhook_base = webhook_url or os.getenv('WEBHOOK_URL')
+        if not self.webhook_base:
+            raise RuntimeError('WEBHOOK_URL not provided')
+        self.webhook_base = self.webhook_base.rstrip('/')
+
+    def call(self, method: str, payload: List[Any] | Dict[str, Any]) -> dict:
+        url = f"{self.webhook_base}/{method}.json"
+        response = requests.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+        return response.json()

--- a/bitrix_client.py
+++ b/bitrix_client.py
@@ -17,3 +17,4 @@ class BitrixClient:
         response = requests.post(url, json=payload, timeout=30)
         response.raise_for_status()
         return response.json()
+

--- a/bitrix_client.py
+++ b/bitrix_client.py
@@ -3,6 +3,8 @@ import requests
 from typing import List, Dict, Any
 
 class BitrixClient:
+    """Simple wrapper for Bitrix24 REST webhook calls."""
+
     def __init__(self, webhook_url: str | None = None) -> None:
         self.webhook_base = webhook_url or os.getenv('WEBHOOK_URL')
         if not self.webhook_base:
@@ -10,6 +12,7 @@ class BitrixClient:
         self.webhook_base = self.webhook_base.rstrip('/')
 
     def call(self, method: str, payload: List[Any] | Dict[str, Any]) -> dict:
+        """Call a REST method and return the response JSON."""
         url = f"{self.webhook_base}/{method}.json"
         response = requests.post(url, json=payload, timeout=30)
         response.raise_for_status()

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from time_log_service import TimeLogService
 
 
 def main() -> None:
+    """Entry point for the CLI."""
     parser = argparse.ArgumentParser(description='Fetch Bitrix24 time logs')
     parser.add_argument('--year', type=int, default=2025, help='Start year')
     parser.add_argument('--month', type=int, default=6, help='Start month (1-12)')
@@ -29,3 +30,4 @@ def main() -> None:
 
 if __name__ == '__main__':
     main()
+

--- a/main.py
+++ b/main.py
@@ -1,56 +1,30 @@
-import requests
-import calendar
-from datetime import datetime
+import argparse
 from dotenv import load_dotenv
-import os
 
-load_dotenv()
-
-WEBHOOK_BASE = os.getenv('WEBHOOK_URL')
-if not WEBHOOK_BASE:
-    raise RuntimeError('WEBHOOK_URL not found in .env')
-
-WEBHOOK_URL = WEBHOOK_BASE.rstrip('/') + '/task.elapseditem.getlist.json'
-
-YEAR = 2025
-MONTH = 6
+from bitrix_client import BitrixClient
+from time_log_service import TimeLogService
 
 
-def get_month_date_range(year: int, month: int):
-    start = datetime(year, month, 1)
-    last_day = calendar.monthrange(year, month)[1]
-    end = datetime(year, month, last_day, 23, 59, 59)
-    return start, end
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Fetch Bitrix24 time logs')
+    parser.add_argument('--year', type=int, default=2025, help='Start year')
+    parser.add_argument('--month', type=int, default=6, help='Start month (1-12)')
+    parser.add_argument('--months', type=int, default=1, help='Number of months to include')
+    parser.add_argument('--show-projects', action='store_true', help='Print list of active projects')
+    args = parser.parse_args()
 
+    load_dotenv()
+    client = BitrixClient()
+    service = TimeLogService(client)
 
-def fetch_time_logs(start_date, end_date, page_size=50):
-    logs = []
-    page = 1
-    while True:
-        payload = [
-            {},
-            {
-                '>=CREATED_DATE': start_date.strftime('%Y-%m-%d'),
-                '<=CREATED_DATE': end_date.strftime('%Y-%m-%d')
-            },
-            ['ID', 'TASK_ID', 'USER_ID', 'CREATED_DATE', 'SECONDS'],
-            {'NAV_PARAMS': {'nPageSize': page_size, 'iNumPage': page}}
-        ]
-        resp = requests.post(WEBHOOK_URL, json=payload, timeout=30)
-        resp.raise_for_status()
-        data = resp.json()
-        logs.extend(data.get('result', []))
-        if not data.get('next'):
-            break
-        page += 1
-    return logs
-
-
-def main():
-    start_date, end_date = get_month_date_range(YEAR, MONTH)
-    logs = fetch_time_logs(start_date, end_date)
+    start_date, end_date = service.compute_range(args.year, args.month, args.months)
+    logs = service.fetch_time_logs(start_date, end_date)
     for log in logs:
         print(log)
+
+    if args.show_projects:
+        projects = service.get_active_projects(start_date, end_date)
+        print('Active projects:', sorted(projects))
 
 
 if __name__ == '__main__':

--- a/time_log_service.py
+++ b/time_log_service.py
@@ -6,11 +6,14 @@ from bitrix_client import BitrixClient
 
 
 class TimeLogService:
+    """Service for working with Bitrix24 time logs."""
+
     def __init__(self, client: BitrixClient) -> None:
         self.client = client
 
     @staticmethod
     def month_date_range(year: int, month: int) -> tuple[datetime, datetime]:
+        """Return the first and last datetime for the given month."""
         start = datetime(year, month, 1)
         last_day = calendar.monthrange(year, month)[1]
         end = datetime(year, month, last_day, 23, 59, 59)
@@ -18,12 +21,14 @@ class TimeLogService:
 
     @staticmethod
     def add_months(date: datetime, months: int) -> datetime:
+        """Return ``date`` shifted by the given number of months."""
         year = date.year + (date.month - 1 + months) // 12
         month = (date.month - 1 + months) % 12 + 1
         day = min(date.day, calendar.monthrange(year, month)[1])
         return date.replace(year=year, month=month, day=day)
 
     def fetch_time_logs(self, start_date: datetime, end_date: datetime, page_size: int = 50) -> List[Dict[str, Any]]:
+        """Retrieve time logs within the given period."""
         logs: List[Dict[str, Any]] = []
         page = 1
         while True:
@@ -44,6 +49,7 @@ class TimeLogService:
         return logs
 
     def get_active_projects(self, start_date: datetime, end_date: datetime) -> Set[int]:
+        """Return project IDs that had task activity in the period."""
         logs = self.fetch_time_logs(start_date, end_date)
         task_ids = {log['TASK_ID'] for log in logs if 'TASK_ID' in log}
         projects: Set[int] = set()
@@ -59,7 +65,9 @@ class TimeLogService:
         return projects
 
     def compute_range(self, year: int, month: int, months: int) -> tuple[datetime, datetime]:
+        """Return a start and end datetime spanning ``months`` months."""
         start, _ = self.month_date_range(year, month)
         end = self.add_months(start, months)
         end -= timedelta(seconds=1)
         return start, end
+

--- a/time_log_service.py
+++ b/time_log_service.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta
+import calendar
+from typing import List, Dict, Any, Set
+
+from bitrix_client import BitrixClient
+
+
+class TimeLogService:
+    def __init__(self, client: BitrixClient) -> None:
+        self.client = client
+
+    @staticmethod
+    def month_date_range(year: int, month: int) -> tuple[datetime, datetime]:
+        start = datetime(year, month, 1)
+        last_day = calendar.monthrange(year, month)[1]
+        end = datetime(year, month, last_day, 23, 59, 59)
+        return start, end
+
+    @staticmethod
+    def add_months(date: datetime, months: int) -> datetime:
+        year = date.year + (date.month - 1 + months) // 12
+        month = (date.month - 1 + months) % 12 + 1
+        day = min(date.day, calendar.monthrange(year, month)[1])
+        return date.replace(year=year, month=month, day=day)
+
+    def fetch_time_logs(self, start_date: datetime, end_date: datetime, page_size: int = 50) -> List[Dict[str, Any]]:
+        logs: List[Dict[str, Any]] = []
+        page = 1
+        while True:
+            payload = [
+                {},
+                {
+                    '>=CREATED_DATE': start_date.strftime('%Y-%m-%d'),
+                    '<=CREATED_DATE': end_date.strftime('%Y-%m-%d')
+                },
+                ['ID', 'TASK_ID', 'USER_ID', 'CREATED_DATE', 'SECONDS'],
+                {'NAV_PARAMS': {'nPageSize': page_size, 'iNumPage': page}}
+            ]
+            data = self.client.call('task.elapseditem.getlist', payload)
+            logs.extend(data.get('result', []))
+            if not data.get('next'):
+                break
+            page += 1
+        return logs
+
+    def get_active_projects(self, start_date: datetime, end_date: datetime) -> Set[int]:
+        logs = self.fetch_time_logs(start_date, end_date)
+        task_ids = {log['TASK_ID'] for log in logs if 'TASK_ID' in log}
+        projects: Set[int] = set()
+        for task_id in task_ids:
+            payload = {'taskId': task_id, 'select': ['ID', 'GROUP_ID']}
+            data = self.client.call('tasks.task.get', payload)
+            task = data.get('result', {}).get('task')
+            if task and 'GROUP_ID' in task:
+                try:
+                    projects.add(int(task['GROUP_ID']))
+                except (ValueError, TypeError):
+                    continue
+        return projects
+
+    def compute_range(self, year: int, month: int, months: int) -> tuple[datetime, datetime]:
+        start, _ = self.month_date_range(year, month)
+        end = self.add_months(start, months)
+        end -= timedelta(seconds=1)
+        return start, end


### PR DESCRIPTION
## Summary
- use `tasks.task.get` instead of obsolete `task.item.get` for project lookup
- allow dictionary payloads in `BitrixClient.call`

## Testing
- `python -m py_compile bitrix_client.py time_log_service.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6866c7ef9948832d8a75eec235fe3b8c