### PR TITLE
Update show-projects behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ pip install -r requirements.txt
 
 3. Run the script. Use `--year` and `--month` to specify the starting month.
 
-   Set `--months` to span multiple months (default is 2) and pass `--show-projects` to print
-   the list of active projects for the selected period.
+   Set `--months` to span multiple months (default is 2). By default the script
+   prints all time log entries. Pass `--show-projects` to print **only** the list
+   of active projects for the selected period.
 
 ```bash
 python main.py --year 2025 --month 6 --months 2 --show-projects
 ```
 
-The command above prints all time log entries for June and July 2025 and shows
-the IDs of projects with any activity during that period.
+The command above prints the IDs of projects with any activity during that period.
 
 ## Docker
 

--- a/main.py
+++ b/main.py
@@ -28,13 +28,14 @@ def main() -> None:
     service = TimeLogService(client)
 
     start_date, end_date = service.compute_range(args.year, args.month, args.months)
-    logs = service.fetch_time_logs(start_date, end_date)
-    for log in logs:
-        print(log)
 
     if args.show_projects:
         projects = service.get_active_projects(start_date, end_date)
         print('Active projects:', sorted(projects))
+    else:
+        logs = service.fetch_time_logs(start_date, end_date)
+        for log in logs:
+            print(log)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- update README to clarify `--show-projects` prints only the project list
- modify `main.py` so that `--show-projects` outputs active project IDs instead of time log entries

## Testing
- `python -m py_compile main.py bitrix/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68677634f330832db37b6c2d61e02890