### PR TITLE
Fix handling of list responses in project fetch

### DIFF
--- a/bitrix/time_log_service.py
+++ b/bitrix/time_log_service.py
@@ -56,6 +56,10 @@ class TimeLogService:
         for task_id in task_ids:
             payload = {'taskId': task_id, 'select': ['ID', 'GROUP_ID']}
             data = self.client.call('tasks.task.get', payload)
+            if isinstance(data, list):
+                data = data[0] if data else {}
+            if not isinstance(data, dict):
+                continue
             task = data.get('result', {}).get('task')
             if task and 'GROUP_ID' in task:
                 try:


### PR DESCRIPTION
## Summary
- handle cases where Bitrix returns a list in `get_active_projects`

## Testing
- `python -m py_compile bitrix/*.py main.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68677aa2929c832d9c473cc31bf9e5b6